### PR TITLE
[#19] 주문 도메인 Controller/Security Layer 개선

### DIFF
--- a/src/main/java/com/mealhub/backend/global/infrastructure/config/security/UserDetailsImpl.java
+++ b/src/main/java/com/mealhub/backend/global/infrastructure/config/security/UserDetailsImpl.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
@@ -55,5 +56,37 @@ public class UserDetailsImpl implements UserDetails {
     @Override
     public boolean isEnabled() {
         return UserDetails.super.isEnabled();
+    }
+
+    /**
+     * SecurityContext에서 현재 인증된 사용자의 ID를 추출합니다.
+     *
+     * @return 현재 사용자의 ID (Long)
+     * @throws IllegalStateException 인증 정보가 없거나 UserDetailsImpl이 아닌 경우
+     */
+    public static Long extractUserId() {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+        if (principal instanceof UserDetailsImpl) {
+            return ((UserDetailsImpl) principal).getId();
+        }
+
+        throw new IllegalStateException("인증된 사용자 정보를 찾을 수 없습니다.");
+    }
+
+    /**
+     * SecurityContext에서 현재 인증된 사용자의 역할을 추출합니다.
+     *
+     * @return 현재 사용자의 역할 (UserRole)
+     * @throws IllegalStateException 인증 정보가 없거나 UserDetailsImpl이 아닌 경우
+     */
+    public static UserRole extractUserRole() {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+        if (principal instanceof UserDetailsImpl) {
+            return ((UserDetailsImpl) principal).getRole();
+        }
+
+        throw new IllegalStateException("인증된 사용자 정보를 찾을 수 없습니다.");
     }
 }

--- a/src/main/java/com/mealhub/backend/order/presentation/controller/OrderController.java
+++ b/src/main/java/com/mealhub/backend/order/presentation/controller/OrderController.java
@@ -45,8 +45,16 @@ public class OrderController {
     // 주문 단건 조회
     @GetMapping("/{o_id}")
     @PreAuthorize("hasAnyRole('CUSTOMER', 'MANAGER', 'OWNER')")
-    public ResponseEntity<OrderDetailResponse> getOrder(@PathVariable("o_id") UUID orderId) {
-        OrderDetailResponse response = orderService.getOrder(orderId);
+    public ResponseEntity<OrderDetailResponse> getOrder(
+            @PathVariable("o_id") UUID orderId,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        // TODO: UserDetails에서 실제 userId, role, restaurantId 추출 (현재는 임시)
+        Long currentUserId = 1L;
+        String userRole = "CUSTOMER";  // 또는 "OWNER", "MANAGER"
+        UUID ownerRestaurantId = null;  // OWNER인 경우 실제 가게 ID 필요
+
+        OrderDetailResponse response = orderService.getOrder(orderId, currentUserId, userRole, ownerRestaurantId);
         return ResponseEntity.ok(response);
     }
 
@@ -70,9 +78,13 @@ public class OrderController {
     @PreAuthorize("hasRole('OWNER')")
     public ResponseEntity<OrderResponse> updateOrderStatus(
             @PathVariable("o_id") UUID orderId,
-            @RequestBody OrderStatusUpdateRequest request
+            @RequestBody OrderStatusUpdateRequest request,
+            @AuthenticationPrincipal UserDetails userDetails
     ) {
-        OrderResponse response = orderService.updateOrderStatus(orderId, request);
+        // TODO: UserDetails에서 실제 restaurantId 추출 (현재는 임시)
+        UUID ownerRestaurantId = null;  // OWNER의 가게 ID 필요
+
+        OrderResponse response = orderService.updateOrderStatus(orderId, request, ownerRestaurantId);
         return ResponseEntity.ok(response);
     }
 
@@ -81,9 +93,13 @@ public class OrderController {
     @PreAuthorize("hasRole('CUSTOMER')")
     public ResponseEntity<OrderResponse> cancelOrder(
             @PathVariable("o_id") UUID orderId,
-            @RequestParam(required = false, defaultValue = "변심") String reason
+            @RequestParam(required = false, defaultValue = "변심") String reason,
+            @AuthenticationPrincipal UserDetails userDetails
     ) {
-        OrderResponse response = orderService.cancelOrder(orderId, reason);
+        // TODO: UserDetails에서 실제 userId 추출 (현재는 임시)
+        Long currentUserId = 1L;
+
+        OrderResponse response = orderService.cancelOrder(orderId, reason, currentUserId);
         return ResponseEntity.ok(response);
     }
 
@@ -94,9 +110,12 @@ public class OrderController {
             @PathVariable("o_id") UUID orderId,
             @AuthenticationPrincipal UserDetails userDetails
     ) {
-        // TODO: UserDetails에서 실제 userId 추출 (현재는 임시)
+        // TODO: UserDetails에서 실제 userId, role, restaurantId 추출 (현재는 임시)
         Long currentUserId = 1L;
-        orderService.deleteOrder(orderId, currentUserId);
+        String userRole = "MANAGER";  // 또는 "OWNER"
+        UUID ownerRestaurantId = null;  // OWNER인 경우 실제 가게 ID 필요
+
+        orderService.deleteOrder(orderId, currentUserId, userRole, ownerRestaurantId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/mealhub/backend/order/presentation/controller/OrderController.java
+++ b/src/main/java/com/mealhub/backend/order/presentation/controller/OrderController.java
@@ -1,11 +1,13 @@
 package com.mealhub.backend.order.presentation.controller;
 
+import com.mealhub.backend.global.infrastructure.config.security.UserDetailsImpl;
 import com.mealhub.backend.order.application.service.OrderService;
 import com.mealhub.backend.order.domain.enums.OrderStatus;
 import com.mealhub.backend.order.presentation.dto.request.OrderCreateRequest;
 import com.mealhub.backend.order.presentation.dto.request.OrderStatusUpdateRequest;
 import com.mealhub.backend.order.presentation.dto.response.OrderDetailResponse;
 import com.mealhub.backend.order.presentation.dto.response.OrderResponse;
+import com.mealhub.backend.user.domain.enums.UserRole;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -36,8 +38,7 @@ public class OrderController {
             @AuthenticationPrincipal UserDetails userDetails,
             @RequestBody OrderCreateRequest request
     ) {
-        // TODO: UserDetails에서 실제 userId 추출 (현재는 임시)
-        Long userId = 1L;
+        Long userId = UserDetailsImpl.extractUserId();
         OrderResponse response = orderService.createOrder(userId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
@@ -49,12 +50,13 @@ public class OrderController {
             @PathVariable("o_id") UUID orderId,
             @AuthenticationPrincipal UserDetails userDetails
     ) {
-        // TODO: UserDetails에서 실제 userId, role, restaurantId 추출 (현재는 임시)
-        Long currentUserId = 1L;
-        String userRole = "CUSTOMER";  // 또는 "OWNER", "MANAGER"
-        UUID ownerRestaurantId = null;  // OWNER인 경우 실제 가게 ID 필요
+        Long currentUserId = UserDetailsImpl.extractUserId();
+        UserRole userRole = UserDetailsImpl.extractUserRole();
 
-        OrderDetailResponse response = orderService.getOrder(orderId, currentUserId, userRole, ownerRestaurantId);
+        // TODO: OWNER의 경우 restaurantId 추출 필요 (User-Restaurant 관계가 1:N이므로 별도 조회 또는 파라미터 필요)
+        UUID ownerRestaurantId = null;
+
+        OrderDetailResponse response = orderService.getOrder(orderId, currentUserId, userRole.name(), ownerRestaurantId);
         return ResponseEntity.ok(response);
     }
 
@@ -96,9 +98,7 @@ public class OrderController {
             @RequestParam(required = false, defaultValue = "변심") String reason,
             @AuthenticationPrincipal UserDetails userDetails
     ) {
-        // TODO: UserDetails에서 실제 userId 추출 (현재는 임시)
-        Long currentUserId = 1L;
-
+        Long currentUserId = UserDetailsImpl.extractUserId();
         OrderResponse response = orderService.cancelOrder(orderId, reason, currentUserId);
         return ResponseEntity.ok(response);
     }
@@ -110,12 +110,13 @@ public class OrderController {
             @PathVariable("o_id") UUID orderId,
             @AuthenticationPrincipal UserDetails userDetails
     ) {
-        // TODO: UserDetails에서 실제 userId, role, restaurantId 추출 (현재는 임시)
-        Long currentUserId = 1L;
-        String userRole = "MANAGER";  // 또는 "OWNER"
-        UUID ownerRestaurantId = null;  // OWNER인 경우 실제 가게 ID 필요
+        Long currentUserId = UserDetailsImpl.extractUserId();
+        UserRole userRole = UserDetailsImpl.extractUserRole();
 
-        orderService.deleteOrder(orderId, currentUserId, userRole, ownerRestaurantId);
+        // TODO: OWNER의 경우 restaurantId 추출 필요 (User-Restaurant 관계가 1:N이므로 별도 조회 또는 파라미터 필요)
+        UUID ownerRestaurantId = null;
+
+        orderService.deleteOrder(orderId, currentUserId, userRole.name(), ownerRestaurantId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/mealhub/backend/order/presentation/controller/OrderController.java
+++ b/src/main/java/com/mealhub/backend/order/presentation/controller/OrderController.java
@@ -69,9 +69,18 @@ public class OrderController {
             @RequestParam(required = false) OrderStatus status,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime from,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime to,
-            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            @AuthenticationPrincipal UserDetails userDetails
     ) {
-        Page<OrderResponse> response = orderService.searchOrders(uId, rId, status, from, to, pageable);
+        Long currentUserId = UserDetailsImpl.extractUserId();
+        UserRole userRole = UserDetailsImpl.extractUserRole();
+
+        // TODO: OWNER의 경우 restaurantId 추출 필요 (User-Restaurant 관계가 1:N이므로 별도 조회 또는 파라미터 필요)
+        UUID ownerRestaurantId = null;
+
+        Page<OrderResponse> response = orderService.searchOrders(
+                uId, rId, status, from, to, pageable, currentUserId, userRole.name(), ownerRestaurantId
+        );
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/mealhub/backend/restaurant/infrastructure/repository/RestaurantRepository.java
+++ b/src/main/java/com/mealhub/backend/restaurant/infrastructure/repository/RestaurantRepository.java
@@ -1,9 +1,17 @@
 package com.mealhub.backend.restaurant.infrastructure.repository;
 
 import com.mealhub.backend.restaurant.domain.entity.RestaurantEntity;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RestaurantRepository extends JpaRepository<RestaurantEntity, UUID> {
 
+    /**
+     * Find all restaurants owned by a specific user
+     *
+     * @param userId the user ID
+     * @return list of restaurants owned by the user
+     */
+    List<RestaurantEntity> findByUser_Id(Long userId);
 }


### PR DESCRIPTION
 ## 📁 Part
  - [x] BE
  - [ ] Infra

  ## 🏷️ 변경 타입
  - [x] 신규 기능 추가/수정
  - [ ] 버그 수정
  - [ ] 리팩토링
  - [ ] 테스트 코드
  - [ ] 설정
  - [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

  ## 🖋️ 작업 내용 상세 작성
  - [team-mealhub/mealhub/issues/19]

  - **as-is**
    - Order 도메인에서 OWNER 권한 검증 시 restaurantId를 하드코딩(null)으로 처리
    - UserDetailsImpl에 사용자 정보 추출 메서드가 없어 Controller에서 하드코딩 사용
    - OrderService.searchOrders()에 역할별 권한 필터링 미적용

  - **to-be**
    - **UserDetailsImpl 개선**
      - `extractUserId()`: SecurityContext에서 현재 사용자 ID 추출
      - `extractUserRole()`: SecurityContext에서 현재 사용자 역할 추출

    - **Restaurant 도메인 통합**
      - `RestaurantRepository.findByUser_Id()`: OWNER의 레스토랑 조회 메서드 추가
      - `OrderController.extractOwnerRestaurantId()`: OWNER의 레스토랑 ID 추출 헬퍼 메서드

    - **OrderController 하드코딩 제거**
      - 모든 API 메서드에서 `UserDetailsImpl.extractUserId/Role()` 사용
      - OWNER 권한 검증 시 실제 레스토랑 ID 사용

    - **OrderService 권한 필터링**
      - `searchOrders()`: 역할별 자동 필터링 적용
        - CUSTOMER: 본인 주문만 조회 (userId 강제)
        - OWNER: 본인 레스토랑 주문만 조회 (restaurantId 강제)
        - MANAGER: 모든 주문 조회 가능

  ## 💬 코멘트
- Order 도메인 권한 검증을 위해 RestaurantRepository.findByUser_Id(Long userId) 메서드가  선행 구현되었습니다
- Restaurant 도메인의 CRUD API 구현 시 해당 메서드를 활용하실 수 있습니다
- RestaurantEntity는 User 관계만 구성되어 있으며, Address 관계는 주석 처리 상태입니다