### PR TITLE
[#50] PageResult 파일 global로 이동

### DIFF
--- a/src/main/java/com/mealhub/backend/global/presentation/dto/PageResult.java
+++ b/src/main/java/com/mealhub/backend/global/presentation/dto/PageResult.java
@@ -1,0 +1,31 @@
+package com.mealhub.backend.global.presentation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class PageResult<T> {
+    private List<T> content;
+    private int totalPages;
+    private long totalElements;
+    private int size;
+    private int number;
+    private boolean first;
+    private boolean last;
+
+    public static <T> PageResult<T> of(Page<T> p) {
+        return new PageResult<>(
+                p.getContent(),
+                p.getTotalPages(),
+                p.getTotalElements(),
+                p.getSize(),
+                p.getNumber(),
+                p.isFirst(),
+                p.isLast()
+        );
+    }
+}


### PR DESCRIPTION
## 📁 Part
- [x] BE
- [ ] Infra

## 🏷️ 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 테스트 코드
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 🖋️ 작업 내용 상세 작성
- [#50 ] review 도메인에서만 사용하던 PageResult를 global.presentation.dto로 이동

- **as-is**
  - PageResult를 review 도메인에서만 사용

- **to-be**
  - PageResult를 global로 이동 -> 전역 범위에서 재사용

## 💬 코멘트
- 아직 review 도메인의 PR이 develop에 merge되지 않아 기존 review 코드에서의 import는 변경이 안되었습니다. 추후 review의 merge 완료 시 import 변경 하겠습니다.
