### PR TITLE
[#53] AddressController 사용자 인증 기반 로직 적용 및 Service 테스트 코드 추가

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,0 +1,26 @@
+name: 🚧 CI - Build & Test (Spring Boot)
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew build -x test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,6 +46,7 @@ jobs:
           host: ${{ secrets.REMOTE_IP }} # 인스턴스 IP
           username: ${{ secrets.REMOTE_USER }} # 우분투 아이디
           password: ${{ secrets.REMOTE_PASSWORD }}
+
           port: ${{ secrets.REMOTE_SSH_PORT }} # 접속포트
           script: | # 실행할 스크립트
             sh deploy.sh

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 
 ### ETC ###
 generated/
+/.env

--- a/src/main/java/com/mealhub/backend/address/presentation/controller/AddressController.java
+++ b/src/main/java/com/mealhub/backend/address/presentation/controller/AddressController.java
@@ -3,11 +3,13 @@ package com.mealhub.backend.address.presentation.controller;
 import com.mealhub.backend.address.application.service.AddressService;
 import com.mealhub.backend.address.presentation.dto.request.AddressRequest;
 import com.mealhub.backend.address.presentation.dto.response.AddressResponse;
+import com.mealhub.backend.global.infrastructure.config.security.UserDetailsImpl;
 import com.mealhub.backend.user.domain.entity.User;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -22,50 +24,49 @@ public class AddressController {
 
     // 주소 등록
     @PostMapping
-    public ResponseEntity<AddressResponse> createAddress(@Valid @RequestBody AddressRequest addressRequest) {
-        // 현재는 임시 mock 사용
-        User mockUser = new User();
-        AddressResponse addressResponse = addressService.create(mockUser, addressRequest);
+    public ResponseEntity<AddressResponse> createAddress(@AuthenticationPrincipal UserDetailsImpl userDetails, @Valid @RequestBody AddressRequest addressRequest) {
+        User currentUser = userDetails.toUser();
+        AddressResponse addressResponse = addressService.create(currentUser, addressRequest);
         return ResponseEntity.status(HttpStatus.CREATED).body(addressResponse);
     }
 
     // 주소 조회(단일)
     @GetMapping("/{id}")
-    public ResponseEntity<AddressResponse> getAddress(@PathVariable UUID id) {
-        User mockUser = new User();
-        AddressResponse addressResponse = addressService.getAddress(mockUser, id);
+    public ResponseEntity<AddressResponse> getAddress(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable UUID id) {
+        User currentUser = userDetails.toUser();
+        AddressResponse addressResponse = addressService.getAddress(currentUser, id);
         return ResponseEntity.ok(addressResponse);
     }
 
     // 전체 주소 조회
     @GetMapping
-    public ResponseEntity<List<AddressResponse>> getAllAddresses() {
-        User mockUser = new User();
-        List<AddressResponse> addressResponses = addressService.getAllAddresses(mockUser);
+    public ResponseEntity<List<AddressResponse>> getAllAddresses(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        User currentUser = userDetails.toUser();
+        List<AddressResponse> addressResponses = addressService.getAllAddresses(currentUser);
         return ResponseEntity.ok(addressResponses);
     }
 
     // 주소 수정
     @PutMapping("/{id}")
-    public ResponseEntity<AddressResponse> updateAddress(@PathVariable UUID id, @Valid @RequestBody AddressRequest addressRequest) {
-        User mockUser = new User();
-        AddressResponse addressResponse = addressService.updateAddress(mockUser, id, addressRequest);
+    public ResponseEntity<AddressResponse> updateAddress(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable UUID id, @Valid @RequestBody AddressRequest addressRequest) {
+        User currentUser = userDetails.toUser();
+        AddressResponse addressResponse = addressService.updateAddress(currentUser, id, addressRequest);
         return ResponseEntity.ok(addressResponse);
     }
 
     // 주소 삭제
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteAddress(@PathVariable UUID id) {
-        User mockUser = new User();
-        addressService.deleteAddress(mockUser, id);
+    public ResponseEntity<Void> deleteAddress(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable UUID id) {
+        User currentUser = userDetails.toUser();
+        addressService.deleteAddress(currentUser, id);
         return ResponseEntity.noContent().build();
     }
 
     // 기본 주소 변경
     @PatchMapping("/{id}/default")
-    public ResponseEntity<AddressResponse> changeDefaultAddress(@PathVariable UUID id) {
-        User mockUser = new User();
-        AddressResponse addressResponse = addressService.changeDefault(mockUser, id);
+    public ResponseEntity<AddressResponse> changeDefaultAddress(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable UUID id) {
+        User currentUser = userDetails.toUser();
+        AddressResponse addressResponse = addressService.changeDefault(currentUser, id);
         return ResponseEntity.ok(addressResponse);
     }
 }


### PR DESCRIPTION
## 📁 Part
- [x] BE
- [ ] Infra

## 🏷️ 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 테스트 코드
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 🖋️ 작업 내용 상세 작성
- [#53](https://github.com/team-mealhub/mealhub/issues/53)

- **as-is**
  - AddressController에서 @Authenticationprincipal 미사용
  - 서비스 테스트 코드 없음

- **to-be**
  - 인증 사용자 기반 로직으로 수정
  - AddressService 단위 테스트 추가

## 💬 코멘트
- Controller 테스트 코드는 오류로 추후 별도 진행 예정