### PR TITLE
[#43] 주소 목록 조회에 검색 기능 추가 및 Service/Controller 단위 테스트 구현 및 수정

### DIFF
--- a/src/main/java/com/mealhub/backend/address/application/service/AddressService.java
+++ b/src/main/java/com/mealhub/backend/address/application/service/AddressService.java
@@ -6,6 +6,8 @@ import com.mealhub.backend.address.presentation.dto.request.AddressRequest;
 import com.mealhub.backend.address.presentation.dto.response.AddressResponse;
 import com.mealhub.backend.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -50,9 +52,16 @@ public class AddressService {
         return toResponse(address);
     }
 
-    // 전체 주소 조회
-    public List<AddressResponse> getAllAddresses(User user) {
-        return addressRepository.findByUser(user).stream()
+    // 전체 주소 조회(+검색, 키워드 없으면 전체 조회)
+    public List<AddressResponse> getAllAddresses(User user, String keyword) {
+        List<Address> result;
+        if (keyword != null && !keyword.trim().isEmpty()) {
+            result = addressRepository.searchAddress(user, keyword.trim());
+        } else {
+            result = addressRepository.findByUser(user);
+        }
+        return result
+                .stream()
                 .map(this::toResponse)
                 .collect(Collectors.toList());
     }
@@ -78,6 +87,8 @@ public class AddressService {
                 addressRequest.getMemo()
         );
 
+        addressRepository.save(address);
+
         return toResponse(address);
     }
 
@@ -100,6 +111,8 @@ public class AddressService {
         return toResponse(target);
     }
 
+
+
     private AddressResponse toResponse(Address address) {
         return new AddressResponse(
                 address.getId(),
@@ -112,4 +125,5 @@ public class AddressService {
                 address.getMemo()
         );
     }
+
 }

--- a/src/main/java/com/mealhub/backend/address/infrastructure/repository/AddressRepository.java
+++ b/src/main/java/com/mealhub/backend/address/infrastructure/repository/AddressRepository.java
@@ -3,6 +3,8 @@ package com.mealhub.backend.address.infrastructure.repository;
 import com.mealhub.backend.address.domain.entity.Address;
 import com.mealhub.backend.user.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -27,4 +29,16 @@ public interface AddressRepository extends JpaRepository<Address, UUID> {
 
     // 사용자 주소 삭제(id기준)
     void deleteByIdAndUser(UUID id, User user);
+
+
+    // 검색 기능(keyword포함 된 주소 조회)
+    @Query("""
+SELECT a FROM Address a WHERE a.user = :user
+AND (
+LOWER(a.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
+OR LOWER(a.address) LIKE LOWER(CONCAT('%', :keyword, '%'))
+OR LOWER(a.oldAddress) LIKE LOWER(CONCAT('%', :keyword, '%'))
+)
+""")
+    List<Address> searchAddress(@Param("user") User user, @Param("keyword") String keyword);
 }

--- a/src/main/java/com/mealhub/backend/address/presentation/controller/AddressController.java
+++ b/src/main/java/com/mealhub/backend/address/presentation/controller/AddressController.java
@@ -5,6 +5,8 @@ import com.mealhub.backend.address.presentation.dto.request.AddressRequest;
 import com.mealhub.backend.address.presentation.dto.response.AddressResponse;
 import com.mealhub.backend.global.infrastructure.config.security.UserDetailsImpl;
 import com.mealhub.backend.user.domain.entity.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -15,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.UUID;
 
+@Tag(name = "주소 API", description = "주소 등록, 조회, 수정, 삭제, 검색 등의 기능 제공")
 @RestController
 @RequestMapping("/v1/addresses")
 @RequiredArgsConstructor
@@ -22,15 +25,16 @@ public class AddressController {
 
     private final AddressService addressService;
 
-    // 주소 등록
+    @Operation(summary = "주소 등록", description = "새로운 주소 등록")
     @PostMapping
     public ResponseEntity<AddressResponse> createAddress(@AuthenticationPrincipal UserDetailsImpl userDetails, @Valid @RequestBody AddressRequest addressRequest) {
+        // 현재는 임시 mock 사용
         User currentUser = userDetails.toUser();
         AddressResponse addressResponse = addressService.create(currentUser, addressRequest);
         return ResponseEntity.status(HttpStatus.CREATED).body(addressResponse);
     }
 
-    // 주소 조회(단일)
+    @Operation(summary = "주소 단일 조회", description = "주소 ID로 특정 주소 조회")
     @GetMapping("/{id}")
     public ResponseEntity<AddressResponse> getAddress(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable UUID id) {
         User currentUser = userDetails.toUser();
@@ -38,15 +42,15 @@ public class AddressController {
         return ResponseEntity.ok(addressResponse);
     }
 
-    // 전체 주소 조회
+    @Operation(summary = "주소 전체 조회", description = "검색어를 포함해 전체 주소 조회")
     @GetMapping
-    public ResponseEntity<List<AddressResponse>> getAllAddresses(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ResponseEntity<List<AddressResponse>> getAllAddresses(@AuthenticationPrincipal UserDetailsImpl userDetails, @RequestParam(required = false) String keyword) {
         User currentUser = userDetails.toUser();
-        List<AddressResponse> addressResponses = addressService.getAllAddresses(currentUser);
+        List<AddressResponse> addressResponses = addressService.getAllAddresses(currentUser, keyword);
         return ResponseEntity.ok(addressResponses);
     }
 
-    // 주소 수정
+    @Operation(summary = "주소 수정", description = "기존 주소 정보 수정")
     @PutMapping("/{id}")
     public ResponseEntity<AddressResponse> updateAddress(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable UUID id, @Valid @RequestBody AddressRequest addressRequest) {
         User currentUser = userDetails.toUser();
@@ -54,7 +58,7 @@ public class AddressController {
         return ResponseEntity.ok(addressResponse);
     }
 
-    // 주소 삭제
+    @Operation(summary = "주소 삭제", description = "주소 ID로 주소 삭제")
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteAddress(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable UUID id) {
         User currentUser = userDetails.toUser();
@@ -62,11 +66,13 @@ public class AddressController {
         return ResponseEntity.noContent().build();
     }
 
-    // 기본 주소 변경
+    @Operation(summary = "기본 주소 변경", description = "특정 주소를 기본 주소로 변경")
     @PatchMapping("/{id}/default")
     public ResponseEntity<AddressResponse> changeDefaultAddress(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable UUID id) {
         User currentUser = userDetails.toUser();
         AddressResponse addressResponse = addressService.changeDefault(currentUser, id);
         return ResponseEntity.ok(addressResponse);
     }
+
 }
+

--- a/src/main/java/com/mealhub/backend/address/presentation/dto/response/AddressResponse.java
+++ b/src/main/java/com/mealhub/backend/address/presentation/dto/response/AddressResponse.java
@@ -1,5 +1,6 @@
 package com.mealhub.backend.address.presentation.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -11,6 +12,8 @@ public class AddressResponse {
 
     private UUID id;
     private String name;
+
+    @JsonProperty("isDefault")
     private boolean isDefault;
     private String address;
     private String oldAddress;

--- a/src/test/java/com/mealhub/backend/address/application/service/AddressServiceTest.java
+++ b/src/test/java/com/mealhub/backend/address/application/service/AddressServiceTest.java
@@ -50,8 +50,8 @@ public class AddressServiceTest {
     }
 
     @Test
-    @DisplayName("새로운 주소 생성 시 기존의 기본주소 해제")
-    void createNewAddress_ExistingDefault() {
+    @DisplayName("주소 생성 성공")
+    void createAddress() {
         AddressRequest addressRequest = new AddressRequest("새로운 집", true, "새 로도명", null, 127.0, 37.0, "메모");
 
         Address address = Address.builder()
@@ -70,8 +70,8 @@ public class AddressServiceTest {
     }
 
     @Test
-    @DisplayName("유효 ID로 주소 조회 성공")
-    void getAddressById_returnAddress() {
+    @DisplayName("주소 단일 조회")
+    void getAddress() {
         when(addressRepository.findByIdAndUser(mockAddressId, mockUser)).thenReturn(Optional.of(mockAddress));
 
         AddressResponse addressResponse = addressService.getAddress(mockUser, mockAddressId);
@@ -89,13 +89,73 @@ public class AddressServiceTest {
     }
 
     @Test
-    @DisplayName("모든 주소 조회 성공")
-    void getAllAddresses_returnAllAddresses() {
+    @DisplayName("주소 전체 조회")
+    void getAllAddresses() {
         when(addressRepository.findByUser(any(User.class))).thenReturn(Collections.singletonList(mockAddress));
 
-        List<AddressResponse> addresses = addressService.getAllAddresses(mockUser);
+        List<AddressResponse> addresses = addressService.getAllAddresses(mockUser, null);
 
         assertThat(addresses).hasSize(1);
         assertThat(addresses.get(0).getName()).isEqualTo("우리 집");
+
+        verify(addressRepository, times(1)).findByUser(mockUser);
+        verify(addressRepository, never()).searchAddress(any(), anyString());
     }
+
+    @Test
+    @DisplayName("주소 수정 성공")
+    void updateAddress() {
+        AddressRequest addressRequest = new AddressRequest("회사", false, "서울시 서초구", null, 127.1, 36.9, "출근용");
+        when(addressRepository.findByIdAndUser(mockAddressId, mockUser)).thenReturn(Optional.of(mockAddress));
+        when(addressRepository.save(any(Address.class))).thenReturn(mockAddress);
+
+        AddressResponse addressResponse = addressService.updateAddress(mockUser, mockAddressId, addressRequest);
+
+        assertThat(addressResponse.getName()).isEqualTo("회사");
+        verify(addressRepository, times(1)).save(any(Address.class));
+    }
+
+    @Test
+    @DisplayName("주소 삭제 성공")
+    void deleteAddress() {
+        UUID id = mockAddressId;
+
+        doNothing().when(addressRepository).deleteByIdAndUser(id, mockUser);
+
+        addressService.deleteAddress(mockUser, id);
+
+        verify(addressRepository, times(1)).deleteByIdAndUser(id, mockUser);
+
+    }
+
+    @Test
+    @DisplayName("주소 검색 성공")
+    void searchAddresses() {
+        when(addressRepository.searchAddress(mockUser, "우리")).thenReturn(Collections.singletonList(mockAddress));
+
+        List<AddressResponse> result = addressService.getAllAddresses(mockUser, "우리");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getName()).isEqualTo("우리 집");
+
+        verify(addressRepository, times(1)).searchAddress(mockUser, "우리");
+        verify(addressRepository, never()).findByUser(any());
+    }
+
+
+    @Test
+    @DisplayName("기본 주소 변경 성공")
+    void changeDefaultAddress() {
+        when(addressRepository.findByIdAndUser(mockAddressId, mockUser)).thenReturn(Optional.of(mockAddress));
+        when(addressRepository.findByUserAndDefaultAddressTrue(mockUser)).thenReturn(Optional.of(mockAddress));
+
+        AddressResponse response = addressService.changeDefault(mockUser, mockAddressId);
+
+        assertThat(response.isDefault()).isTrue();
+        verify(addressRepository, times(1)).findByUserAndDefaultAddressTrue(mockUser);
+        verify(addressRepository, times(1)).findByIdAndUser(mockAddressId, mockUser);
+    }
+
+
 }
+

--- a/src/test/java/com/mealhub/backend/address/presentation/AddressControllerTest.java
+++ b/src/test/java/com/mealhub/backend/address/presentation/AddressControllerTest.java
@@ -1,4 +1,0 @@
-package com.mealhub.backend.address.presentation;
-
-public class AddressControllerTest {
-}

--- a/src/test/java/com/mealhub/backend/address/presentation/controller/AddressControllerTest.java
+++ b/src/test/java/com/mealhub/backend/address/presentation/controller/AddressControllerTest.java
@@ -1,0 +1,205 @@
+package com.mealhub.backend.address.presentation.controller;
+
+import com.mealhub.backend.address.application.service.AddressService;
+import com.mealhub.backend.address.presentation.dto.request.AddressRequest;
+import com.mealhub.backend.address.presentation.dto.response.AddressResponse;
+import com.mealhub.backend.global.domain.application.libs.MessageUtils;
+import com.mealhub.backend.global.infrastructure.config.security.UserDetailsImpl;
+import com.mealhub.backend.user.domain.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(AddressController.class)
+@MockitoBean(types = AddressService.class)
+@MockitoBean(types = MessageUtils.class)
+public class AddressControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private AddressService addressService;
+
+    @WithMockUser
+    @Test
+    @DisplayName("주소 등록 성공")
+    void createAddress() throws Exception {
+        UUID id = UUID.randomUUID();
+        AddressResponse addressResponse = new AddressResponse(
+                id, "우리집", true, "서울시 강남구", null, 127.0, 37.0, "메모");
+
+        Mockito.when(addressService.create(any(), any(AddressRequest.class))).thenReturn(addressResponse);
+
+        UserDetailsImpl mockUserDetails = mock(UserDetailsImpl.class);
+        Mockito.when(mockUserDetails.toUser()).thenReturn(new User());
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/v1/addresses")
+                        .with(csrf())
+                        .with(authentication(new UsernamePasswordAuthenticationToken(mockUserDetails, null, mockUserDetails.getAuthorities())))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+{
+"name": "우리집",
+"isDefault": true,
+"address": "서울시 강남구",
+"longitude": 127.0,
+"latitude": 37.0,
+"memo": "메모"
+}
+"""))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name").value("우리집"))
+                .andExpect(jsonPath("$.isDefault").value(true))
+                .andDo(MockMvcResultHandlers.print());
+
+    }
+
+    @Test
+    @DisplayName("주소 단일 조회")
+    @WithMockUser
+    void getAddress() throws Exception {
+        UUID id = UUID.randomUUID();
+        AddressResponse addressResponse = new AddressResponse(
+                id, "우리집", true, "서울시 강남구", null, 127.0, 37.0, "메모");
+
+        Mockito.when(addressService.getAddress(any(), eq(id))).thenReturn(addressResponse);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/v1/addresses/" + id)
+                        .with(csrf())
+                        .with(authentication(new UsernamePasswordAuthenticationToken(mock(UserDetailsImpl.class), null, List.of())))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("우리집"))
+                .andExpect(jsonPath("$.isDefault").value(true))
+                .andDo(MockMvcResultHandlers.print());
+    }
+
+    @Test
+    @DisplayName("주소 전체 조회")
+    @WithMockUser
+    void getAllAddresses() throws Exception {
+        UUID id = UUID.randomUUID();
+        AddressResponse addressResponse = new AddressResponse(
+                id, "우리집", true, "서울시 강남구", null, 127.0, 37.0, "메모");
+
+        Mockito.when(addressService.getAllAddresses(any(), any())).thenReturn(List.of(addressResponse));
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/v1/addresses")
+                        .with(csrf())
+                        .with(authentication(new UsernamePasswordAuthenticationToken(mockPrincipal(), null, List.of()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].name").value("우리집"))
+                .andDo(MockMvcResultHandlers.print());
+    }
+
+    private UserDetailsImpl mockPrincipal() {
+        UserDetailsImpl mockUserDetails = Mockito.mock(UserDetailsImpl.class);
+        Mockito.when(mockUserDetails.toUser()).thenReturn(new User());
+        return mockUserDetails;
+    }
+
+    @Test
+    @DisplayName("주소 수정 성공")
+    @WithMockUser
+    void updateAddress() throws Exception {
+        UUID id = UUID.randomUUID();
+        AddressResponse addressResponse = new AddressResponse(
+                id, "회사", false, "서울시 서초구", null, 127.1, 37.1, "출근용"
+        );
+
+        Mockito.when(addressService.updateAddress(any(), eq(id), any(AddressRequest.class))).thenReturn(addressResponse);
+
+        mockMvc.perform(MockMvcRequestBuilders.put("/v1/addresses/" + id)
+                        .with(csrf())
+                        .with(authentication(new UsernamePasswordAuthenticationToken(mockPrincipal(), null, List.of())))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+{
+"name": "회사",
+"isDefault": false,
+"address": "서울시 서초구",
+"longitude": 127.1,
+"latitude": 37.1,
+"memo": "출근용"
+
+}
+"""))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("회사"))
+                .andDo(MockMvcResultHandlers.print());
+    }
+
+    @Test
+    @DisplayName("주소 삭제 성공")
+    @WithMockUser
+    void deleteAddress() throws Exception {
+        UUID id = UUID.randomUUID();
+
+        mockMvc.perform(MockMvcRequestBuilders.delete("/v1/addresses/" + id)
+                        .with(csrf())
+                        .with(authentication(new UsernamePasswordAuthenticationToken(mockPrincipal(), null, List.of()))))
+                .andExpect(status().isNoContent())
+                .andDo(MockMvcResultHandlers.print());
+        Mockito.verify(addressService, Mockito.times(1)).deleteAddress(any(), eq(id));
+    }
+
+    @Test
+    @DisplayName("주소 검색 성공")
+    @WithMockUser
+    void searchAddresses() throws Exception {
+        UUID id = UUID.randomUUID();
+        AddressResponse addressResponse = new AddressResponse(
+                id, "우리집", true, "서울시 강남구", null, 127.0, 37.0, "메모");
+
+        Mockito.when(addressService.getAllAddresses(any(), eq("우리"))).thenReturn(List.of(addressResponse));
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/v1/addresses")
+                        .param("keyword", "우리")
+                        .with(csrf())
+                        .with(authentication(new UsernamePasswordAuthenticationToken(mockPrincipal(), null, List.of()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].name").value("우리집"))
+                .andDo(MockMvcResultHandlers.print());
+    }
+
+
+    @Test
+    @DisplayName("기본 주소 변경 성공")
+    @WithMockUser
+    void changeDefaultAddress() throws Exception {
+        UUID id = UUID.randomUUID();
+        AddressResponse addressResponse = new AddressResponse(
+                id, "우리집", true, "서울시 강남구", null, 127.0, 37.0, "메모");
+
+        Mockito.when(addressService.changeDefault(any(), eq(id))).thenReturn(addressResponse);
+
+        mockMvc.perform(MockMvcRequestBuilders.patch("/v1/addresses/" + id + "/default")
+                        .with(csrf())
+                        .with(authentication(new UsernamePasswordAuthenticationToken(mockPrincipal(), null, List.of()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isDefault").value(true))
+                .andDo(MockMvcResultHandlers.print());
+
+    }
+}
+


### PR DESCRIPTION
## 📁 Part
- [x] BE
- [ ] Infra

## 🏷️ 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 테스트 코드
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 🖋️ 작업 내용 상세 작성
- [#43](https://github.com/team-mealhub/mealhub/issues/43)

- **as-is**
  - 기존 주소 전체 조회만 가능
  - 검색 기능 없음
  - controller테스트 없음

- **to-be**
  - 검색 기능 구현 (키워드 포함 주소 조회 기능 추가)
  -  AddressControllerTest 작성 및 주요 API 테스트 추가
  - AddressServiceTest 테스트 추가

## 💬 코멘트
- 검색 기능 + 단위 테스트 코드 구현 완료