### PR TITLE
[#44] 주소 도메인 페이징, soft-delete추가 및 단위 테스트 추가

### DIFF
--- a/src/main/java/com/mealhub/backend/address/domain/entity/Address.java
+++ b/src/main/java/com/mealhub/backend/address/domain/entity/Address.java
@@ -44,6 +44,9 @@ public class Address extends BaseAuditEntity {
     @Column(name = "a_memo", length = 255)
     private String memo;
 
+    @Column(name = "a_deleted", nullable = false)
+    private boolean deleted = false;
+
     @Builder
     private Address(User user, String name, boolean defaultAddress, String address,
                     String oldAddress, Double longitude, Double latitude, String memo) {
@@ -70,5 +73,9 @@ public class Address extends BaseAuditEntity {
 
     public void changeDefault(boolean defaultAddress) {
         this.defaultAddress = defaultAddress;
+    }
+
+    public void softDelete() {
+        this.deleted = true;
     }
 }

--- a/src/main/java/com/mealhub/backend/address/infrastructure/repository/AddressRepository.java
+++ b/src/main/java/com/mealhub/backend/address/infrastructure/repository/AddressRepository.java
@@ -2,12 +2,14 @@ package com.mealhub.backend.address.infrastructure.repository;
 
 import com.mealhub.backend.address.domain.entity.Address;
 import com.mealhub.backend.user.domain.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -15,30 +17,32 @@ import java.util.UUID;
 @Repository
 public interface AddressRepository extends JpaRepository<Address, UUID> {
 
-    // 사용자 모든주소목록
-    List<Address> findByUser(User user);
+    // 사용자 모든주소목록 (페이징 적용)
+    Page<Address> findByUserAndDeletedFalse(User user, Pageable pageable);
 
     //사용자 기본 주소
-    Optional<Address> findByUserAndDefaultAddressTrue(User user);
+    Optional<Address> findByUserAndDefaultAddressTrueAndDeletedFalse(User user);
 
     // 사용자 기본 주소 존재 여부
-    boolean existsByUserAndDefaultAddressTrue(User user);
+    boolean existsByUserAndDefaultAddressTrueAndDeletedFalse(User user);
 
     // 사용자 주소 조회(id기준)
-    Optional<Address> findByIdAndUser(UUID id, User user);
+    Optional<Address> findByIdAndUserAndDeletedFalse(UUID id, User user);
 
-    // 사용자 주소 삭제(id기준)
-    void deleteByIdAndUser(UUID id, User user);
+    // soft-delete
+    @Modifying
+    @Query("UPDATE Address a SET a.deleted = true WHERE a.id = :id AND a.user = :user AND a.deleted = false")
+    void softDeleteByIdAndUser(@Param("id") UUID id, @Param("user") User user);
 
 
-    // 검색 기능(keyword포함 된 주소 조회)
+    // 검색 기능(keyword포함 된 주소 조회 / 페이징 적용)
     @Query("""
-SELECT a FROM Address a WHERE a.user = :user
+SELECT a FROM Address a WHERE a.user = :user AND a.deleted = false
 AND (
 LOWER(a.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
 OR LOWER(a.address) LIKE LOWER(CONCAT('%', :keyword, '%'))
 OR LOWER(a.oldAddress) LIKE LOWER(CONCAT('%', :keyword, '%'))
 )
 """)
-    List<Address> searchAddress(@Param("user") User user, @Param("keyword") String keyword);
+    Page<Address> searchAddress(@Param("user") User user, @Param("keyword") String keyword, Pageable pageable);
 }

--- a/src/main/java/com/mealhub/backend/address/presentation/controller/AddressController.java
+++ b/src/main/java/com/mealhub/backend/address/presentation/controller/AddressController.java
@@ -9,6 +9,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -28,7 +30,6 @@ public class AddressController {
     @Operation(summary = "주소 등록", description = "새로운 주소 등록")
     @PostMapping
     public ResponseEntity<AddressResponse> createAddress(@AuthenticationPrincipal UserDetailsImpl userDetails, @Valid @RequestBody AddressRequest addressRequest) {
-        // 현재는 임시 mock 사용
         User currentUser = userDetails.toUser();
         AddressResponse addressResponse = addressService.create(currentUser, addressRequest);
         return ResponseEntity.status(HttpStatus.CREATED).body(addressResponse);
@@ -42,11 +43,11 @@ public class AddressController {
         return ResponseEntity.ok(addressResponse);
     }
 
-    @Operation(summary = "주소 전체 조회", description = "검색어를 포함해 전체 주소 조회")
+    @Operation(summary = "주소 전체 조회", description = "검색어를 포함해 전체 주소 페이징 조회")
     @GetMapping
-    public ResponseEntity<List<AddressResponse>> getAllAddresses(@AuthenticationPrincipal UserDetailsImpl userDetails, @RequestParam(required = false) String keyword) {
+    public ResponseEntity<Page<AddressResponse>> getAllAddresses(@AuthenticationPrincipal UserDetailsImpl userDetails, @RequestParam(required = false) String keyword, Pageable pageable) {
         User currentUser = userDetails.toUser();
-        List<AddressResponse> addressResponses = addressService.getAllAddresses(currentUser, keyword);
+        Page<AddressResponse> addressResponses = addressService.getAllAddresses(currentUser, keyword, pageable);
         return ResponseEntity.ok(addressResponses);
     }
 

--- a/src/test/java/com/mealhub/backend/address/application/service/AddressServiceTest.java
+++ b/src/test/java/com/mealhub/backend/address/application/service/AddressServiceTest.java
@@ -12,6 +12,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Collections;
 import java.util.List;
@@ -59,8 +63,8 @@ public class AddressServiceTest {
                 .defaultAddress(true)
                 .build();
 
-        when(addressRepository.existsByUserAndDefaultAddressTrue(any(User.class))).thenReturn(true);
-        when(addressRepository.findByUserAndDefaultAddressTrue(any(User.class))).thenReturn(Optional.of(address));
+        when(addressRepository.existsByUserAndDefaultAddressTrueAndDeletedFalse(any(User.class))).thenReturn(true);
+        when(addressRepository.findByUserAndDefaultAddressTrueAndDeletedFalse(any(User.class))).thenReturn(Optional.of(address));
         when(addressRepository.save(any(Address.class))).thenReturn(mockAddress);
 
         addressService.create(mockUser, addressRequest);
@@ -72,7 +76,7 @@ public class AddressServiceTest {
     @Test
     @DisplayName("주소 단일 조회")
     void getAddress() {
-        when(addressRepository.findByIdAndUser(mockAddressId, mockUser)).thenReturn(Optional.of(mockAddress));
+        when(addressRepository.findByIdAndUserAndDeletedFalse(mockAddressId, mockUser)).thenReturn(Optional.of(mockAddress));
 
         AddressResponse addressResponse = addressService.getAddress(mockUser, mockAddressId);
 
@@ -83,30 +87,35 @@ public class AddressServiceTest {
     @Test
     @DisplayName("유효하지 않은 ID 조회 시 예외 발생")
     void getAddressByInvalidId_throwsException() {
-        when(addressRepository.findByIdAndUser(any(UUID.class), any(User.class))).thenReturn(Optional.empty());
+        when(addressRepository.findByIdAndUserAndDeletedFalse(any(UUID.class), any(User.class))).thenReturn(Optional.empty());
 
         assertThrows(RuntimeException.class, () -> addressService.getAddress(mockUser, UUID.randomUUID()));
     }
 
     @Test
-    @DisplayName("주소 전체 조회")
+    @DisplayName("주소 전체 페이징 조회")
     void getAllAddresses() {
-        when(addressRepository.findByUser(any(User.class))).thenReturn(Collections.singletonList(mockAddress));
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<Address> page = new PageImpl<>(Collections.singletonList(mockAddress));
 
-        List<AddressResponse> addresses = addressService.getAllAddresses(mockUser, null);
+        when(addressRepository.findByUserAndDeletedFalse(mockUser, pageable)).thenReturn(page);
+
+        Page<AddressResponse> addresses = addressService.getAllAddresses(mockUser, null, pageable);
 
         assertThat(addresses).hasSize(1);
-        assertThat(addresses.get(0).getName()).isEqualTo("우리 집");
+        assertThat(addresses.getContent().get(0).getName()).isEqualTo("우리 집");
 
-        verify(addressRepository, times(1)).findByUser(mockUser);
-        verify(addressRepository, never()).searchAddress(any(), anyString());
+        verify(addressRepository, times(1)).findByUserAndDeletedFalse(mockUser, pageable);
+        verify(addressRepository, never()).searchAddress(any(), any(), any());
+
+
     }
 
     @Test
     @DisplayName("주소 수정 성공")
     void updateAddress() {
         AddressRequest addressRequest = new AddressRequest("회사", false, "서울시 서초구", null, 127.1, 36.9, "출근용");
-        when(addressRepository.findByIdAndUser(mockAddressId, mockUser)).thenReturn(Optional.of(mockAddress));
+        when(addressRepository.findByIdAndUserAndDeletedFalse(mockAddressId, mockUser)).thenReturn(Optional.of(mockAddress));
         when(addressRepository.save(any(Address.class))).thenReturn(mockAddress);
 
         AddressResponse addressResponse = addressService.updateAddress(mockUser, mockAddressId, addressRequest);
@@ -120,40 +129,43 @@ public class AddressServiceTest {
     void deleteAddress() {
         UUID id = mockAddressId;
 
-        doNothing().when(addressRepository).deleteByIdAndUser(id, mockUser);
+        doNothing().when(addressRepository).softDeleteByIdAndUser(id, mockUser);
 
         addressService.deleteAddress(mockUser, id);
 
-        verify(addressRepository, times(1)).deleteByIdAndUser(id, mockUser);
+        verify(addressRepository, times(1)).softDeleteByIdAndUser(id, mockUser);
 
     }
 
     @Test
-    @DisplayName("주소 검색 성공")
+    @DisplayName("주소 검색 성공 - 페이징 포함")
     void searchAddresses() {
-        when(addressRepository.searchAddress(mockUser, "우리")).thenReturn(Collections.singletonList(mockAddress));
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<Address> page = new PageImpl<>(Collections.singletonList(mockAddress));
 
-        List<AddressResponse> result = addressService.getAllAddresses(mockUser, "우리");
+        when(addressRepository.searchAddress(mockUser, "우리", pageable)).thenReturn(page);
 
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).getName()).isEqualTo("우리 집");
+        Page<AddressResponse> result = addressService.getAllAddresses(mockUser, "우리", pageable);
 
-        verify(addressRepository, times(1)).searchAddress(mockUser, "우리");
-        verify(addressRepository, never()).findByUser(any());
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getName()).isEqualTo("우리 집");
+
+        verify(addressRepository, times(1)).searchAddress(mockUser, "우리", pageable);
+        verify(addressRepository, never()).findByUserAndDeletedFalse(any(), any());
     }
 
 
     @Test
     @DisplayName("기본 주소 변경 성공")
     void changeDefaultAddress() {
-        when(addressRepository.findByIdAndUser(mockAddressId, mockUser)).thenReturn(Optional.of(mockAddress));
-        when(addressRepository.findByUserAndDefaultAddressTrue(mockUser)).thenReturn(Optional.of(mockAddress));
+        when(addressRepository.findByIdAndUserAndDeletedFalse(mockAddressId, mockUser)).thenReturn(Optional.of(mockAddress));
+        when(addressRepository.findByUserAndDefaultAddressTrueAndDeletedFalse(mockUser)).thenReturn(Optional.of(mockAddress));
 
         AddressResponse response = addressService.changeDefault(mockUser, mockAddressId);
 
         assertThat(response.isDefault()).isTrue();
-        verify(addressRepository, times(1)).findByUserAndDefaultAddressTrue(mockUser);
-        verify(addressRepository, times(1)).findByIdAndUser(mockAddressId, mockUser);
+        verify(addressRepository, times(1)).findByUserAndDefaultAddressTrueAndDeletedFalse(mockUser);
+        verify(addressRepository, times(1)).findByIdAndUserAndDeletedFalse(mockAddressId, mockUser);
     }
 
 

--- a/src/test/java/com/mealhub/backend/address/presentation/controller/AddressControllerTest.java
+++ b/src/test/java/com/mealhub/backend/address/presentation/controller/AddressControllerTest.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -95,20 +97,22 @@ public class AddressControllerTest {
     }
 
     @Test
-    @DisplayName("주소 전체 조회")
+    @DisplayName("주소 전체 조회 - 페이징")
     @WithMockUser
     void getAllAddresses() throws Exception {
         UUID id = UUID.randomUUID();
         AddressResponse addressResponse = new AddressResponse(
                 id, "우리집", true, "서울시 강남구", null, 127.0, 37.0, "메모");
 
-        Mockito.when(addressService.getAllAddresses(any(), any())).thenReturn(List.of(addressResponse));
+        Page<AddressResponse> mockPage = new PageImpl<>(List.of(addressResponse));
+
+        Mockito.when(addressService.getAllAddresses(any(), any(), any())).thenReturn(mockPage);
 
         mockMvc.perform(MockMvcRequestBuilders.get("/v1/addresses")
                         .with(csrf())
                         .with(authentication(new UsernamePasswordAuthenticationToken(mockPrincipal(), null, List.of()))))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].name").value("우리집"))
+                .andExpect(jsonPath("$.content[0].name").value("우리집"))
                 .andDo(MockMvcResultHandlers.print());
     }
 
@@ -150,7 +154,7 @@ public class AddressControllerTest {
     }
 
     @Test
-    @DisplayName("주소 삭제 성공")
+    @DisplayName("주소 soft-delete 성공")
     @WithMockUser
     void deleteAddress() throws Exception {
         UUID id = UUID.randomUUID();
@@ -171,14 +175,16 @@ public class AddressControllerTest {
         AddressResponse addressResponse = new AddressResponse(
                 id, "우리집", true, "서울시 강남구", null, 127.0, 37.0, "메모");
 
-        Mockito.when(addressService.getAllAddresses(any(), eq("우리"))).thenReturn(List.of(addressResponse));
+        Page<AddressResponse> mockPage = new PageImpl<>(List.of(addressResponse));
+
+        Mockito.when(addressService.getAllAddresses(any(), eq("우리"), any())).thenReturn(mockPage);
 
         mockMvc.perform(MockMvcRequestBuilders.get("/v1/addresses")
                         .param("keyword", "우리")
                         .with(csrf())
                         .with(authentication(new UsernamePasswordAuthenticationToken(mockPrincipal(), null, List.of()))))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].name").value("우리집"))
+                .andExpect(jsonPath("$.content[0].name").value("우리집"))
                 .andDo(MockMvcResultHandlers.print());
     }
 


### PR DESCRIPTION
## 📁 Part
- [x] BE
- [ ] Infra

## 🏷️ 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 테스트 코드
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 🖋️ 작업 내용 상세 작성
- [#44]

- **as-is**
  - deleteByIdAndUser로만 주소 삭제 가능
  - 조회 시 삭제된 데이터도 포함
  - 전체 주소 목록 조회 시 페이징 미적

- **to-be**
  - soft-delete 적용(조회/검색/기본주소)
  - Pageable 기반 페이징 적용(조회/검색 시 일정 단위로 나눠서 반환)
  - 단위테스트로 페이징/soft-delete 기능 검증

## 💬 코멘트
- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)
